### PR TITLE
fix: update deploy URL configuration

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -47,7 +47,7 @@ jobs:
           go-version: "1.24"
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v5
       - name: Setup Hugo
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,4 +1,4 @@
-baseURL: https://www.baggiponte.com/
+baseURL: https://baggiponte.com/
 languageCode: en-us
 title: baggiponte
 


### PR DESCRIPTION
## Summary
- Update Hugo base URL from www.baggiponte.com to baggiponte.com
- Upgrade GitHub Actions configure-pages action from v4 to v5

## Test plan
- [ ] Verify site deploys correctly with new base URL
- [ ] Confirm GitHub Pages workflow runs successfully

🤖 Generated with [Claude Code](https://claude.ai/code)