### PR TITLE
Redesign minimal blog interface

### DIFF
--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -307,8 +307,12 @@ body {
   margin: 0.5rem 0;
 }
 
-.article-toc .toc-level-3 {
+.article-toc .toc-level-2 {
   margin-left: 0.8rem;
+}
+
+.article-toc .toc-level-3 {
+  margin-left: 1.6rem;
 }
 
 .article-toc a {

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -108,7 +108,7 @@ body {
 
 .home-copy,
 .list-intro,
-.article-header p {
+.article-subtitle-row p {
   max-width: 46rem;
   margin-top: 1.35rem;
   color: var(--site-muted);
@@ -230,8 +230,21 @@ body {
   font-size: 0.9rem;
 }
 
+.article-subtitle-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 1.35rem;
+}
+
+.article-subtitle-row p {
+  margin-top: 0;
+}
+
 .copy-markdown-button {
-  margin-top: 1.25rem;
+  flex: 0 0 auto;
+  margin-top: 0;
   border: 1px solid var(--site-border);
   border-radius: 999px;
   background: var(--site-surface);
@@ -352,21 +365,21 @@ body {
 
 .highlight .chroma {
   background: transparent !important;
-  color: #d7deea;
+  color: #f0f6fc;
 }
 
 .hextra-code-block .highlight .chroma .n {
-  color: #cbd5e1;
+  color: #f0f6fc;
 }
 
 .hextra-code-block .highlight .chroma .nf,
 .hextra-code-block .highlight .chroma .fm {
-  color: #8bd5ca;
+  color: #d2a8ff;
   font-weight: 650;
 }
 
 .hextra-code-block .highlight .chroma .nc {
-  color: #f2b56b;
+  color: #ffa657;
   font-weight: 650;
 }
 
@@ -374,54 +387,51 @@ body {
 .hextra-code-block .highlight .chroma .kn,
 .hextra-code-block .highlight .chroma .kc,
 .hextra-code-block .highlight .chroma .ow {
-  color: #c9a7ff;
+  color: #ff7b72;
   font-weight: 650;
 }
 
 .hextra-code-block .highlight .chroma .nb,
 .hextra-code-block .highlight .chroma .bp {
-  color: #9ccfd8;
+  color: #79c0ff;
 }
 
 .hextra-code-block .highlight .chroma .nn {
-  color: #a8b5c7;
+  color: #a5d6ff;
 }
 
-.hextra-code-block .highlight .chroma .o {
-  color: #f0a6a6;
-}
-
+.hextra-code-block .highlight .chroma .o,
 .hextra-code-block .highlight .chroma .p {
-  color: #8f9bae;
+  color: #c9d1d9;
 }
 
 .hextra-code-block .highlight .chroma .s,
 .hextra-code-block .highlight .chroma .s1,
 .hextra-code-block .highlight .chroma .s2,
 .hextra-code-block .highlight .chroma .sd {
-  color: #a8cc8c;
+  color: #a5d6ff;
 }
 
 .hextra-code-block .highlight .chroma .m,
 .hextra-code-block .highlight .chroma .mi,
 .hextra-code-block .highlight .chroma .mf {
-  color: #f2c866;
+  color: #79c0ff;
 }
 
 .hextra-code-block .highlight .chroma .c,
 .hextra-code-block .highlight .chroma .c1,
 .hextra-code-block .highlight .chroma .cm {
-  color: #7f8a9b;
+  color: #8b949e;
   font-style: italic;
 }
 
 .hextra-code-block .highlight .chroma .nd {
-  color: #e6b3d1;
+  color: #d2a8ff;
   font-weight: 600;
 }
 
 .hextra-code-block .highlight .chroma .o + .n {
-  color: #7fb4ff;
+  color: #79c0ff;
 }
 
 @media (max-width: 72rem) {
@@ -452,5 +462,9 @@ body {
   .post-row a {
     grid-template-columns: 1fr;
     gap: 0.45rem;
+  }
+
+  .article-subtitle-row {
+    flex-direction: column;
   }
 }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -148,7 +148,7 @@ body {
 
 .post-row a {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-columns: minmax(0, 1fr) 8.5rem;
   gap: 2rem;
   padding: 1.15rem 0;
   border-bottom: 1px solid var(--site-border);
@@ -176,6 +176,7 @@ body {
 }
 
 .post-row time {
+  justify-self: end;
   white-space: nowrap;
 }
 
@@ -199,8 +200,8 @@ body {
 
 .article-frame {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 18rem;
-  gap: clamp(2rem, 5vw, 5rem);
+  grid-template-columns: minmax(0, 1fr) minmax(12rem, 16rem);
+  gap: clamp(1.5rem, 4vw, 4.5rem);
   padding: 4.5rem 0 7rem;
 }
 
@@ -335,14 +336,29 @@ body {
 .hextra-code-block {
   margin: 1.8rem 0;
   font-size: 0.92rem;
+  position: relative;
 }
 
 .hextra-code-block pre,
 .content pre {
   border: 1px solid var(--site-border) !important;
   border-radius: 1rem !important;
-  background: var(--site-code-bg) !important;
   box-shadow: 0 18px 48px rgba(0, 0, 0, 0.14);
+}
+
+.hextra-code-copy-btn-container {
+  margin: 0 !important;
+  opacity: 1 !important;
+  right: 0.65rem !important;
+  top: 0.65rem !important;
+  z-index: 2;
+}
+
+.hextra-code-copy-btn {
+  background: var(--site-surface) !important;
+  border-color: var(--site-border) !important;
+  color: var(--site-ink) !important;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.12);
 }
 
 .hextra-code-block code,
@@ -360,81 +376,9 @@ body {
 .hextra-code-filename {
   border-bottom: 1px solid var(--site-border);
   border-radius: 1rem 1rem 0 0 !important;
-  background: color-mix(in srgb, var(--site-code-bg) 92%, white) !important;
 }
 
-.highlight .chroma {
-  background: transparent !important;
-  color: #f0f6fc;
-}
-
-.hextra-code-block .highlight .chroma .n {
-  color: #f0f6fc;
-}
-
-.hextra-code-block .highlight .chroma .nf,
-.hextra-code-block .highlight .chroma .fm {
-  color: #d2a8ff;
-  font-weight: 650;
-}
-
-.hextra-code-block .highlight .chroma .nc {
-  color: #ffa657;
-  font-weight: 650;
-}
-
-.hextra-code-block .highlight .chroma .k,
-.hextra-code-block .highlight .chroma .kn,
-.hextra-code-block .highlight .chroma .kc,
-.hextra-code-block .highlight .chroma .ow {
-  color: #ff7b72;
-  font-weight: 650;
-}
-
-.hextra-code-block .highlight .chroma .nb,
-.hextra-code-block .highlight .chroma .bp {
-  color: #79c0ff;
-}
-
-.hextra-code-block .highlight .chroma .nn {
-  color: #a5d6ff;
-}
-
-.hextra-code-block .highlight .chroma .o,
-.hextra-code-block .highlight .chroma .p {
-  color: #c9d1d9;
-}
-
-.hextra-code-block .highlight .chroma .s,
-.hextra-code-block .highlight .chroma .s1,
-.hextra-code-block .highlight .chroma .s2,
-.hextra-code-block .highlight .chroma .sd {
-  color: #a5d6ff;
-}
-
-.hextra-code-block .highlight .chroma .m,
-.hextra-code-block .highlight .chroma .mi,
-.hextra-code-block .highlight .chroma .mf {
-  color: #79c0ff;
-}
-
-.hextra-code-block .highlight .chroma .c,
-.hextra-code-block .highlight .chroma .c1,
-.hextra-code-block .highlight .chroma .cm {
-  color: #8b949e;
-  font-style: italic;
-}
-
-.hextra-code-block .highlight .chroma .nd {
-  color: #d2a8ff;
-  font-weight: 600;
-}
-
-.hextra-code-block .highlight .chroma .o + .n {
-  color: #79c0ff;
-}
-
-@media (max-width: 72rem) {
+@media (max-width: 56rem) {
   .article-frame {
     grid-template-columns: 1fr;
   }

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -1,0 +1,456 @@
+:root {
+  --hextra-max-page-width: 108rem;
+  --site-bg: #f7f5f0;
+  --site-surface: rgba(255, 255, 255, 0.68);
+  --site-border: rgba(18, 24, 38, 0.1);
+  --site-muted: #687083;
+  --site-ink: #151922;
+  --site-code-bg: #10141d;
+}
+
+:root.dark {
+  --site-bg: #0e1014;
+  --site-surface: rgba(20, 23, 30, 0.72);
+  --site-border: rgba(229, 231, 235, 0.12);
+  --site-muted: #9aa3b5;
+  --site-ink: #edf0f6;
+  --site-code-bg: #11151f;
+}
+
+body {
+  background:
+    radial-gradient(circle at top left, rgba(99, 102, 241, 0.08), transparent 26rem),
+    var(--site-bg);
+  color: var(--site-ink);
+  font-feature-settings: "kern", "liga", "calt";
+  text-rendering: optimizeLegibility;
+}
+
+.hextra-nav-container-blur {
+  background: color-mix(in srgb, var(--site-bg) 86%, transparent) !important;
+  border-bottom: 1px solid var(--site-border);
+  box-shadow: none !important;
+  backdrop-filter: blur(18px);
+}
+
+.hextra-max-navbar-width {
+  max-width: 108rem !important;
+}
+
+.hextra-nav-container nav {
+  gap: 0.35rem;
+}
+
+.hextra-nav-container a,
+.hextra-theme-toggle {
+  border-radius: 999px !important;
+}
+
+.hextra-nav-container a[href="/"] span {
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.hextra-search-wrapper {
+  width: 13.5rem;
+}
+
+.hextra-search-input {
+  height: 2.25rem;
+  border: 1px solid var(--site-border) !important;
+  border-radius: 999px !important;
+  background: var(--site-surface) !important;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+}
+
+.hextra-search-input::placeholder {
+  color: var(--site-muted) !important;
+}
+
+.hextra-search-wrapper kbd {
+  border-radius: 999px !important;
+}
+
+.site-shell,
+.article-frame {
+  width: min(100% - 2rem, 96rem);
+  margin: 0 auto;
+}
+
+.site-shell {
+  padding: 5.5rem 0 7rem;
+}
+
+.home-hero {
+  max-width: 56rem;
+  padding-bottom: 5rem;
+}
+
+.eyebrow {
+  margin: 0 0 1rem;
+  color: var(--site-muted);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.home-hero h1,
+.list-header h1,
+.article-header h1 {
+  margin: 0;
+  color: var(--site-ink);
+  font-size: clamp(2.6rem, 7vw, 6.8rem);
+  font-weight: 760;
+  letter-spacing: -0.055em;
+  line-height: 0.92;
+}
+
+.home-copy,
+.list-intro,
+.article-header p {
+  max-width: 46rem;
+  margin-top: 1.35rem;
+  color: var(--site-muted);
+  font-size: 1.08rem;
+  line-height: 1.7;
+}
+
+.section-heading {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid var(--site-border);
+  padding-bottom: 0.85rem;
+}
+
+.section-heading h2 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: -0.02em;
+}
+
+.section-heading a,
+.blog-pager a {
+  color: var(--site-muted);
+  font-size: 0.9rem;
+  text-decoration: none;
+}
+
+.post-list {
+  border-top: 1px solid var(--site-border);
+}
+
+.section-heading + .post-list {
+  border-top: 0;
+}
+
+.post-row a {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 2rem;
+  padding: 1.15rem 0;
+  border-bottom: 1px solid var(--site-border);
+  color: inherit;
+  text-decoration: none;
+}
+
+.post-row-main {
+  display: grid;
+  gap: 0.25rem;
+  min-width: 0;
+}
+
+.post-row-title {
+  font-size: clamp(1.2rem, 2vw, 1.55rem);
+  font-weight: 650;
+  letter-spacing: -0.025em;
+}
+
+.post-row-description,
+.post-row time {
+  color: var(--site-muted);
+  font-size: 0.95rem;
+  line-height: 1.5;
+}
+
+.post-row time {
+  white-space: nowrap;
+}
+
+.post-row a:hover .post-row-title,
+.section-heading a:hover,
+.blog-pager a:hover {
+  color: hsl(var(--primary-hue), 80%, 45%);
+}
+
+.list-header {
+  max-width: 60rem;
+  margin-bottom: 3rem;
+}
+
+.blog-pager {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.article-frame {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 18rem;
+  gap: clamp(2rem, 5vw, 5rem);
+  padding: 4.5rem 0 7rem;
+}
+
+.article-main {
+  min-width: 0;
+}
+
+.article-header {
+  margin-bottom: 2.5rem;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid var(--site-border);
+}
+
+.article-header h1 {
+  max-width: 72rem;
+  font-size: clamp(2.6rem, 5.8vw, 6rem);
+  letter-spacing: -0.045em;
+}
+
+.article-meta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.1rem;
+  color: var(--site-muted);
+  font-size: 0.9rem;
+}
+
+.copy-markdown-button {
+  margin-top: 1.25rem;
+  border: 1px solid var(--site-border);
+  border-radius: 999px;
+  background: var(--site-surface);
+  color: var(--site-ink);
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 650;
+  padding: 0.55rem 0.85rem;
+}
+
+.copy-markdown-button:hover {
+  border-color: color-mix(in srgb, var(--site-muted) 44%, var(--site-border));
+}
+
+.article-content {
+  max-width: none;
+  font-size: 1.02rem;
+  line-height: 1.78;
+}
+
+.article-content > :first-child {
+  margin-top: 0;
+}
+
+.article-toc {
+  display: block;
+}
+
+.article-toc-inner {
+  position: sticky;
+  top: 5.5rem;
+  max-height: calc(100vh - 7rem);
+  overflow: auto;
+  border-left: 1px solid var(--site-border);
+  padding-left: 1.25rem;
+  color: var(--site-muted);
+  font-size: 0.88rem;
+}
+
+.article-toc-inner p {
+  margin: 0 0 0.9rem;
+  color: var(--site-ink);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+}
+
+.article-toc nav ul {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.article-toc nav ul ul {
+  margin-top: 0.45rem;
+  padding-left: 0.8rem;
+}
+
+.article-toc li {
+  margin: 0.5rem 0;
+}
+
+.article-toc .toc-level-3 {
+  margin-left: 0.8rem;
+}
+
+.article-toc a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.article-toc a:hover {
+  color: var(--site-ink);
+}
+
+.content :where(h2, h3, h4) {
+  color: var(--site-ink);
+  letter-spacing: -0.025em;
+}
+
+.content :where(p, li) {
+  color: color-mix(in srgb, var(--site-ink) 82%, var(--site-muted));
+}
+
+.content a {
+  text-underline-offset: 0.18em;
+}
+
+.hextra-code-block {
+  margin: 1.8rem 0;
+  font-size: 0.92rem;
+}
+
+.hextra-code-block pre,
+.content pre {
+  border: 1px solid var(--site-border) !important;
+  border-radius: 1rem !important;
+  background: var(--site-code-bg) !important;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.14);
+}
+
+.hextra-code-block code,
+.content code {
+  font-variant-ligatures: none;
+}
+
+.content :not(pre) > code {
+  border: 1px solid var(--site-border);
+  border-radius: 0.4rem;
+  background: color-mix(in srgb, var(--site-muted) 12%, transparent);
+  padding: 0.12rem 0.32rem;
+}
+
+.hextra-code-filename {
+  border-bottom: 1px solid var(--site-border);
+  border-radius: 1rem 1rem 0 0 !important;
+  background: color-mix(in srgb, var(--site-code-bg) 92%, white) !important;
+}
+
+.highlight .chroma {
+  background: transparent !important;
+  color: #d7deea;
+}
+
+.hextra-code-block .highlight .chroma .n {
+  color: #cbd5e1;
+}
+
+.hextra-code-block .highlight .chroma .nf,
+.hextra-code-block .highlight .chroma .fm {
+  color: #8bd5ca;
+  font-weight: 650;
+}
+
+.hextra-code-block .highlight .chroma .nc {
+  color: #f2b56b;
+  font-weight: 650;
+}
+
+.hextra-code-block .highlight .chroma .k,
+.hextra-code-block .highlight .chroma .kn,
+.hextra-code-block .highlight .chroma .kc,
+.hextra-code-block .highlight .chroma .ow {
+  color: #c9a7ff;
+  font-weight: 650;
+}
+
+.hextra-code-block .highlight .chroma .nb,
+.hextra-code-block .highlight .chroma .bp {
+  color: #9ccfd8;
+}
+
+.hextra-code-block .highlight .chroma .nn {
+  color: #a8b5c7;
+}
+
+.hextra-code-block .highlight .chroma .o {
+  color: #f0a6a6;
+}
+
+.hextra-code-block .highlight .chroma .p {
+  color: #8f9bae;
+}
+
+.hextra-code-block .highlight .chroma .s,
+.hextra-code-block .highlight .chroma .s1,
+.hextra-code-block .highlight .chroma .s2,
+.hextra-code-block .highlight .chroma .sd {
+  color: #a8cc8c;
+}
+
+.hextra-code-block .highlight .chroma .m,
+.hextra-code-block .highlight .chroma .mi,
+.hextra-code-block .highlight .chroma .mf {
+  color: #f2c866;
+}
+
+.hextra-code-block .highlight .chroma .c,
+.hextra-code-block .highlight .chroma .c1,
+.hextra-code-block .highlight .chroma .cm {
+  color: #7f8a9b;
+  font-style: italic;
+}
+
+.hextra-code-block .highlight .chroma .nd {
+  color: #e6b3d1;
+  font-weight: 600;
+}
+
+.hextra-code-block .highlight .chroma .o + .n {
+  color: #7fb4ff;
+}
+
+@media (max-width: 72rem) {
+  .article-frame {
+    grid-template-columns: 1fr;
+  }
+
+  .article-toc {
+    display: none;
+  }
+}
+
+@media (max-width: 48rem) {
+  .hextra-search-wrapper {
+    width: min(48vw, 12rem);
+  }
+
+  .site-shell,
+  .article-frame {
+    width: min(100% - 1.25rem, 96rem);
+  }
+
+  .site-shell,
+  .article-frame {
+    padding-top: 3.25rem;
+  }
+
+  .post-row a {
+    grid-template-columns: 1fr;
+    gap: 0.45rem;
+  }
+}

--- a/assets/css/custom.css
+++ b/assets/css/custom.css
@@ -142,6 +142,10 @@ body {
   border-top: 1px solid var(--site-border);
 }
 
+.about-copy {
+  margin-top: 1.5rem;
+}
+
 .section-heading + .post-list {
   border-top: 0;
 }

--- a/assets/js/copy-markdown.js
+++ b/assets/js/copy-markdown.js
@@ -1,0 +1,20 @@
+document.addEventListener("click", async (event) => {
+  const button = event.target.closest("[data-copy-markdown]");
+  if (!button) return;
+
+  const source = document.querySelector("[data-markdown-source]");
+  if (!source) return;
+
+  const original = button.textContent;
+  try {
+    const markdown = source.value || source.textContent;
+    await navigator.clipboard.writeText(markdown.trim() + "\n");
+    button.textContent = "Copied";
+  } catch {
+    button.textContent = "Copy failed";
+  }
+
+  window.setTimeout(() => {
+    button.textContent = original;
+  }, 1600);
+});

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,4 +4,8 @@ draft: false
 title: ''
 ---
 
-I am an AI engineer and open source enthusiast.
+I'm an AI engineer and open-source enthusiast. I write about machine
+learning and deep learning — the theory, the clean code and abstractions
+behind it, and the hard-won lessons from shipping real projects.
+
+<!-- write your real bio here -->

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,7 +4,4 @@ draft: false
 title: ''
 ---
 
-
-# 👋 Welcome!
-
-I am an AI Engineer an open source enthusiast.
+I am an AI engineer and open source enthusiast.

--- a/content/_index.md
+++ b/content/_index.md
@@ -4,8 +4,3 @@ draft: false
 title: ''
 ---
 
-I'm an AI engineer and open-source enthusiast. I write about machine
-learning and deep learning — the theory, the clean code and abstractions
-behind it, and the hard-won lessons from shipping real projects.
-
-<!-- write your real bio here -->

--- a/content/about.md
+++ b/content/about.md
@@ -1,0 +1,12 @@
+---
+date: '2025-06-13T19:50:00+02:00'
+draft: false
+title: 'About'
+type: about
+---
+
+I'm an AI engineer and open-source enthusiast. I write about machine
+learning and deep learning — the theory, the clean code and abstractions
+behind it, and the hard-won lessons from shipping real projects.
+
+<!-- write your real bio here -->

--- a/content/about.md
+++ b/content/about.md
@@ -1,7 +1,7 @@
 ---
 date: '2025-06-13T19:50:00+02:00'
 draft: false
-title: 'About'
+title: 'about'
 type: about
 ---
 

--- a/content/blog/01-groundup-linear-regression/index.md
+++ b/content/blog/01-groundup-linear-regression/index.md
@@ -1,6 +1,7 @@
 ---
 title: "From the Ground Up: Linear Regression"
 description: We implement a simple linear regression in PyTorch, introducing a couple of abstractions while keeping the training loop easy to follow.
+date: 2026-02-18
 ---
 
 {{< include-md "linear_regression.md" >}}

--- a/content/blog/01-groundup-linear-regression/linear_regression.md
+++ b/content/blog/01-groundup-linear-regression/linear_regression.md
@@ -1,6 +1,6 @@
 ---
 title: Linear Regression
-marimo-version: 0.19.11
+marimo-version: 0.23.14
 width: full
 sql_output: native
 ---
@@ -118,7 +118,7 @@ for i in range(EPOCHS):
     result["params"].append(params)
 ```
 
-# Let's add some abstractions
+## Let's add some abstractions
 <!---->
 This code works just fine. But, as soon as you change the model, you need to make changes to other parts of the code. For example, say you want to add a second layer to the linear regression (and thus make it a proper multi-layer perceptron, or MLP): now you have to change the signature of `predict`, to accept more parameters. Are you going to pass more parameters? Make the function accept variadic (`*args`) weights? Or are you going to shove all weights in a list?
 

--- a/content/blog/01-groundup-linear-regression/linear_regression.py
+++ b/content/blog/01-groundup-linear-regression/linear_regression.py
@@ -184,7 +184,7 @@ def _(X, b, mean_squared_error, params, predict, w, y):
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    # Let's add some abstractions
+    ## Let's add some abstractions
     """)
     return
 

--- a/content/blog/02-groundup-linear-classifier/index.md
+++ b/content/blog/02-groundup-linear-classifier/index.md
@@ -1,6 +1,7 @@
 ---
 title: "From the Ground Up: Linear Classifier"
 description: We move from linear regression to classification and build a logistic regression plus a more structured PyTorch training loop.
+date: 2026-02-18
 draft: true
 ---
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -4,4 +4,4 @@ draft: false
 title: 'Blog'
 ---
 
-Long form contents
+Long-form notes on machine learning, tools, and the engineering details around them.

--- a/content/blog/groundup-linear-classifier/index.md
+++ b/content/blog/groundup-linear-classifier/index.md
@@ -1,0 +1,8 @@
+---
+title: "from the ground up: linear classifier"
+description: We move from linear regression to classification and build a logistic regression plus a more structured PyTorch training loop.
+date: 2026-02-18
+draft: true
+---
+
+{{< include-md "linear_classifier.md" >}}

--- a/content/blog/groundup-linear-regression/index.md
+++ b/content/blog/groundup-linear-regression/index.md
@@ -1,0 +1,7 @@
+---
+title: "from the ground up: linear regression"
+description: We implement a simple linear regression in PyTorch, introducing a couple of abstractions while keeping the training loop easy to follow.
+date: 2026-02-18
+---
+
+{{< include-md "linear_regression.md" >}}

--- a/content/til/_index.md
+++ b/content/til/_index.md
@@ -1,7 +1,0 @@
----
-date: '2025-06-13T19:59:59+02:00'
-draft: false
-title: 'TIL'
----
-
-Short stuff I learned

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -2,11 +2,19 @@ baseURL: https://baggiponte.com/
 languageCode: en-us
 title: baggiponte
 
+author:
+  name: baggiponte
+
 module:
   imports:
     - path: github.com/imfing/hextra
 
 params:
+  navbar:
+    displayLogo: false
+    displayTitle: true
+    width: full
+
   theme:
     default: light
     displayToggle: true
@@ -19,7 +27,10 @@ params:
       orderBy: "date"
       order: "desc"
     article:
-      displayPagination: true
+      displayPagination: false
+
+  toc:
+    displayTags: false
 
   footer:
     enable: false
@@ -44,6 +55,11 @@ menu:
       weight: 7
       params:
         type: search
+    - identifier: theme-toggle
+      name: Theme
+      weight: 8
+      params:
+        type: theme-toggle
 
 taxonomies:
   tag: tags
@@ -52,3 +68,4 @@ taxonomies:
 markup:
   highlight:
     noClasses: false
+    lineNos: false

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -43,10 +43,6 @@ menu:
       name: Blog
       url: /blog/
       weight: 1
-    - identifier: til
-      name: TIL
-      url: /til/
-      weight: 2
     - identifier: talks
       name: Talks
       url: https://sessionize.com/lucabaggi/

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -39,9 +39,9 @@ params:
 
 menu:
   main:
-    - identifier: blog
-      name: Blog
-      url: /blog/
+    - identifier: about
+      name: About
+      url: /about/
       weight: 1
     - identifier: talks
       name: Talks

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 baseURL: https://baggiponte.com/
 languageCode: en-us
-title: AI Field Notes
+title: ai field notes
 
 author:
   name: baggiponte
@@ -40,11 +40,11 @@ params:
 menu:
   main:
     - identifier: about
-      name: About
+      name: about
       url: /about/
       weight: 1
     - identifier: talks
-      name: Talks
+      name: talks
       url: https://sessionize.com/lucabaggi/
       weight: 3
     - name: Search

--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,6 +1,6 @@
 baseURL: https://baggiponte.com/
 languageCode: en-us
-title: baggiponte
+title: AI Field Notes
 
 author:
   name: baggiponte

--- a/layouts/_partials/favicons.html
+++ b/layouts/_partials/favicons.html
@@ -1,0 +1,1 @@
+<link rel="icon" href="{{ "favicon.svg" | relURL }}" type="image/svg+xml" id="favicon-svg" />

--- a/layouts/about/single.html
+++ b/layouts/about/single.html
@@ -1,0 +1,10 @@
+{{ define "main" }}
+  <main class="site-shell about-page" aria-labelledby="about-title">
+    <header class="list-header">
+      {{ if .Title }}<h1 id="about-title">{{ .Title }}</h1>{{ end }}
+    </header>
+    <div class="content about-copy">
+      {{ .Content }}
+    </div>
+  </main>
+{{ end }}

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -4,7 +4,7 @@
   {{- $paginator := .Paginate $pages $pagerSize -}}
   <main class="site-shell blog-list-page" aria-labelledby="blog-title">
     <header class="list-header">
-      <p class="eyebrow">Archive</p>
+      <p class="eyebrow">archive</p>
       {{ if .Title }}<h1 id="blog-title">{{ .Title }}</h1>{{ end }}
       <div class="content list-intro">{{ .Content }}</div>
     </header>

--- a/layouts/blog/list.html
+++ b/layouts/blog/list.html
@@ -1,0 +1,25 @@
+{{ define "main" }}
+  {{- $pages := partial "utils/sort-pages" (dict "page" . "by" site.Params.blog.list.orderBy "order" site.Params.blog.list.order) -}}
+  {{- $pagerSize := site.Params.blog.list.pagerSize | default 12 -}}
+  {{- $paginator := .Paginate $pages $pagerSize -}}
+  <main class="site-shell blog-list-page" aria-labelledby="blog-title">
+    <header class="list-header">
+      <p class="eyebrow">Archive</p>
+      {{ if .Title }}<h1 id="blog-title">{{ .Title }}</h1>{{ end }}
+      <div class="content list-intro">{{ .Content }}</div>
+    </header>
+
+    <div class="post-list">
+      {{ range $paginator.Pages }}
+        {{ partial "blog/post-row.html" . }}
+      {{ end }}
+    </div>
+
+    {{- if gt $paginator.TotalPages 1 -}}
+      <nav class="blog-pager" aria-label="Pagination">
+        {{ with $paginator.Prev }}<a href="{{ .URL }}">Newer</a>{{ end }}
+        {{ with $paginator.Next }}<a href="{{ .URL }}">Older</a>{{ end }}
+      </nav>
+    {{- end -}}
+  </main>
+{{ end }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -7,8 +7,10 @@
           {{ if .Params.tags }}{{ partial "tags.html" (dict "context" .) }}{{ end }}
         </div>
         {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
-        {{ with .Description }}<p>{{ . }}</p>{{ end }}
-        <button class="copy-markdown-button" type="button" data-copy-markdown aria-live="polite">Copy as Markdown</button>
+        <div class="article-subtitle-row">
+          {{ with .Description }}<p>{{ . }}</p>{{ end }}
+          <button class="copy-markdown-button" type="button" data-copy-markdown aria-live="polite">Copy as Markdown</button>
+        </div>
       </header>
 
       {{ partial "blog/copy-markdown.html" . }}

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -1,0 +1,28 @@
+{{ define "main" }}
+  <div class="article-frame">
+    <article class="article-main">
+      <header class="article-header">
+        <div class="article-meta">
+          {{ with .Date }}<time datetime="{{ .Format "2006-01-02" }}">{{ partial "utils/format-date" . }}</time>{{ end }}
+          {{ if .Params.tags }}{{ partial "tags.html" (dict "context" .) }}{{ end }}
+        </div>
+        {{ if .Title }}<h1>{{ .Title }}</h1>{{ end }}
+        {{ with .Description }}<p>{{ . }}</p>{{ end }}
+        <button class="copy-markdown-button" type="button" data-copy-markdown aria-live="polite">Copy as Markdown</button>
+      </header>
+
+      {{ partial "blog/copy-markdown.html" . }}
+
+      <div class="content article-content">
+        {{ .Content }}
+      </div>
+    </article>
+
+    <aside class="article-toc" aria-label="Table of contents">
+      <div class="article-toc-inner">
+        <p>Index</p>
+        {{ partial "blog/toc.html" . }}
+      </div>
+    </aside>
+  </div>
+{{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+  {{- $posts := where .Site.RegularPages "Section" "blog" -}}
+  {{- $posts = where $posts "Draft" false -}}
+  <main class="site-shell blog-home" aria-labelledby="home-title">
+    <section class="home-hero">
+      <p class="eyebrow">baggiponte</p>
+      <h1 id="home-title">Readable notes on practical machine learning.</h1>
+      <div class="home-copy content">
+        {{ .Content }}
+      </div>
+    </section>
+
+    <section class="post-section" aria-labelledby="latest-posts">
+      <div class="section-heading">
+        <h2 id="latest-posts">Latest writing</h2>
+        <a href="{{ "blog/" | relURL }}">All posts</a>
+      </div>
+      <div class="post-list compact-post-list">
+        {{ range first 5 $posts.ByDate.Reverse }}
+          {{ partial "blog/post-row.html" . }}
+        {{ else }}
+          <p>No posts yet.</p>
+        {{ end }}
+      </div>
+    </section>
+  </main>
+{{ end }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,26 +1,16 @@
 {{ define "main" }}
-  {{- $posts := where .Site.RegularPages "Section" "blog" -}}
-  {{- $posts = where $posts "Draft" false -}}
   <main class="site-shell blog-home" aria-labelledby="home-title">
     <section class="home-hero">
-      <p class="eyebrow">baggiponte</p>
-      <h1 id="home-title">Readable notes on practical machine learning.</h1>
-      <div class="home-copy content">
-        {{ .Content }}
-      </div>
+      <h1 id="home-title">AI Field Notes</h1>
+      <p class="home-copy">Plus the hard-won lessons, ramblings, and (hot) takes in between</p>
     </section>
 
-    <section class="post-section" aria-labelledby="latest-posts">
+    <section class="about-section" aria-labelledby="about-heading">
       <div class="section-heading">
-        <h2 id="latest-posts">Latest writing</h2>
-        <a href="{{ "blog/" | relURL }}">All posts</a>
+        <h2 id="about-heading">About</h2>
       </div>
-      <div class="post-list compact-post-list">
-        {{ range first 5 $posts.ByDate.Reverse }}
-          {{ partial "blog/post-row.html" . }}
-        {{ else }}
-          <p>No posts yet.</p>
-        {{ end }}
+      <div class="about-copy content">
+        {{ .Content }}
       </div>
     </section>
   </main>

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -3,13 +3,13 @@
   {{- $posts = where $posts "Draft" false -}}
   <main class="site-shell blog-home" aria-labelledby="home-title">
     <section class="home-hero">
-      <h1 id="home-title">AI Field Notes</h1>
+      <h1 id="home-title">ai field notes</h1>
       <p class="home-copy">Plus the hard-won lessons, ramblings, and (hot) takes in between</p>
     </section>
 
     <section class="post-section" aria-labelledby="writing-heading">
       <div class="section-heading">
-        <h2 id="writing-heading">Writing</h2>
+        <h2 id="writing-heading">writing</h2>
       </div>
       <div class="post-list compact-post-list">
         {{ range $posts.ByDate.Reverse }}

--- a/layouts/home.html
+++ b/layouts/home.html
@@ -1,16 +1,22 @@
 {{ define "main" }}
+  {{- $posts := where .Site.RegularPages "Section" "blog" -}}
+  {{- $posts = where $posts "Draft" false -}}
   <main class="site-shell blog-home" aria-labelledby="home-title">
     <section class="home-hero">
       <h1 id="home-title">AI Field Notes</h1>
       <p class="home-copy">Plus the hard-won lessons, ramblings, and (hot) takes in between</p>
     </section>
 
-    <section class="about-section" aria-labelledby="about-heading">
+    <section class="post-section" aria-labelledby="writing-heading">
       <div class="section-heading">
-        <h2 id="about-heading">About</h2>
+        <h2 id="writing-heading">Writing</h2>
       </div>
-      <div class="about-copy content">
-        {{ .Content }}
+      <div class="post-list compact-post-list">
+        {{ range $posts.ByDate.Reverse }}
+          {{ partial "blog/post-row.html" . }}
+        {{ else }}
+          <p>No posts yet.</p>
+        {{ end }}
       </div>
     </section>
   </main>

--- a/layouts/list.rss.xml
+++ b/layouts/list.rss.xml
@@ -1,0 +1,37 @@
+{{- $author := .Site.Params.author -}}
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>{{ .Site.Title }} - {{ .Title }}</title>
+    <link>{{ .Permalink }}</link>
+    <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.LanguageCode }}
+    <language>{{ . }}</language>{{ end }}{{ with $author.email }}
+    <managingEditor>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $author.email }}
+    <webMaster>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}
+    <copyright>{{ . }}</copyright>{{ end }}{{ if not .Date.IsZero }}
+    <lastBuildDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</lastBuildDate>{{ end }}
+    {{ with .OutputFormats.Get "RSS" }}
+    {{ printf "<atom:link href=%q rel=\"self\" type=%q />" .Permalink .MediaType | safeHTML }}
+    {{ end }}
+    {{ if not $.Section }}
+      {{ $sections := .Site.Params.rss.sections | default (slice "blog") }}
+      {{ .Store.Set "rssPages" (first 50 (where $.Site.RegularPages "Type" "in" $sections)) }}
+    {{ else }}
+      {{ if $.Parent.IsHome }}
+        {{ .Store.Set "rssPages" (first 50 (where $.Site.RegularPages "Type" $.Section)) }}
+      {{ else }}
+        {{ .Store.Set "rssPages" (first 50 $.Pages) }}
+      {{ end }}
+    {{ end }}
+    {{ range (.Store.Get "rssPages") }}
+    <item>
+      <title>{{ .Title }}</title>
+      <link>{{ .Permalink }}</link>
+      <pubDate>{{ .Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}</pubDate>
+      {{ with $author.email }}<author>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</author>{{ end }}
+      <guid>{{ .Permalink }}</guid>
+      <description>{{ .Content | html }}</description>
+    </item>
+    {{ end }}
+  </channel>
+</rss>

--- a/layouts/partials/blog/copy-markdown.html
+++ b/layouts/partials/blog/copy-markdown.html
@@ -1,0 +1,15 @@
+{{- $markdown := .RawContent -}}
+{{- with findRESubmatch `\{\{<\s*include-md\s+"([^"]+)"\s*>\}\}` .RawContent 1 -}}
+  {{- with index . 0 -}}
+    {{- $include := index . 1 -}}
+    {{- with $.File -}}
+      {{- $path := path.Join "content" .Dir $include -}}
+      {{- if fileExists $path -}}
+        {{- $markdown = readFile $path -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- $markdown = replaceRE `(?s)^---\n.*?\n---\n?` "" $markdown -}}
+{{- $title := printf "# %s\n\n" .Title -}}
+<textarea hidden readonly data-markdown-source>{{ printf "%s%s" $title $markdown }}</textarea>

--- a/layouts/partials/blog/post-row.html
+++ b/layouts/partials/blog/post-row.html
@@ -1,0 +1,9 @@
+<article class="post-row">
+  <a href="{{ .RelPermalink }}" aria-label="Read {{ .Title }}">
+    <span class="post-row-main">
+      <span class="post-row-title">{{ .Title }}</span>
+      <span class="post-row-description">{{ partial "utils/page-description" . }}</span>
+    </span>
+    {{ with .Date }}<time datetime="{{ .Format "2006-01-02" }}">{{ .Format "Jan 2, 2006" }}</time>{{ end }}
+  </a>
+</article>

--- a/layouts/partials/blog/post-row.html
+++ b/layouts/partials/blog/post-row.html
@@ -4,6 +4,6 @@
       <span class="post-row-title">{{ .Title }}</span>
       <span class="post-row-description">{{ partial "utils/page-description" . }}</span>
     </span>
-    {{ with .Date }}<time datetime="{{ .Format "2006-01-02" }}">{{ .Format "Jan 2, 2006" }}</time>{{ end }}
+    {{ with .Date }}<time class="post-row-date" datetime="{{ .Format "2006-01-02" }}">{{ .Format "Jan 2, 2006" }}</time>{{ end }}
   </a>
 </article>

--- a/layouts/partials/blog/toc.html
+++ b/layouts/partials/blog/toc.html
@@ -6,7 +6,7 @@
   <nav id="TableOfContents">
     <ul>
       {{- range $included -}}
-        {{- if ge .level 2 -}}
+        {{- if ge .level 1 -}}
           <li class="toc-level-{{ .level }}"><a href="#{{ .id }}">{{ .text }}</a></li>
         {{- end -}}
       {{- end -}}

--- a/layouts/partials/blog/toc.html
+++ b/layouts/partials/blog/toc.html
@@ -1,0 +1,15 @@
+{{- $native := .TableOfContents -}}
+{{- $included := .Store.Get "includedHeadings" -}}
+{{- if and $native (not (eq $native `<nav id="TableOfContents"></nav>`)) -}}
+  {{- $native -}}
+{{- else if $included -}}
+  <nav id="TableOfContents">
+    <ul>
+      {{- range $included -}}
+        {{- if ge .level 2 -}}
+          <li class="toc-level-{{ .level }}"><a href="#{{ .id }}">{{ .text }}</a></li>
+        {{- end -}}
+      {{- end -}}
+    </ul>
+  </nav>
+{{- end -}}

--- a/layouts/partials/custom/head-end.html
+++ b/layouts/partials/custom/head-end.html
@@ -1,0 +1,7 @@
+{{- $copyMarkdown := resources.Get "js/copy-markdown.js" -}}
+{{- if $copyMarkdown -}}
+  {{- if hugo.IsProduction -}}
+    {{- $copyMarkdown = $copyMarkdown | minify | fingerprint -}}
+  {{- end -}}
+  <script defer src="{{ $copyMarkdown.RelPermalink }}"{{ with $copyMarkdown.Data.Integrity }} integrity="{{ . }}"{{ end }}></script>
+{{- end -}}

--- a/layouts/partials/search.html
+++ b/layouts/partials/search.html
@@ -1,0 +1,25 @@
+{{- $placeholder := (T "searchPlaceholder") | default "Search" -}}
+
+<div class="hextra-search-wrapper hx:relative hx:md:w-64">
+  <div class="hx:relative hx:flex hx:items-center hx:text-gray-900 hx:contrast-more:text-gray-800 hx:dark:text-gray-300 hx:contrast-more:dark:text-gray-300">
+    <input
+      placeholder="{{ replace $placeholder "..." "" }}"
+      class="hextra-search-input hx:focus:hextra-focus hx:block hx:w-full hx:appearance-none hx:rounded-lg hx:px-3 hx:py-2 hx:transition-colors hx:text-base hx:leading-tight hx:md:text-sm hx:bg-black/[.05] hx:dark:bg-gray-50/10 hx:focus:bg-white hx:dark:focus:bg-dark hx:placeholder:text-gray-500 hx:dark:placeholder:text-gray-400 hx:contrast-more:border hx:contrast-more:border-current"
+      type="search"
+      value=""
+      spellcheck="false"
+    />
+    <kbd
+      class="hx:absolute hx:my-1.5 hx:select-none hx:ltr:right-1.5 hx:rtl:left-1.5 hx:h-5 hx:rounded-sm hx:bg-white hx:px-1.5 hx:font-mono hx:text-[10px] hx:font-medium hx:text-gray-500 hx:border hx:border-gray-200 hx:dark:border-gray-100/20 hx:dark:bg-dark/50 hx:contrast-more:border-current hx:contrast-more:text-current hx:contrast-more:dark:border-current hx:items-center hx:gap-1 hx:transition-opacity hx:pointer-events-none hx:hidden hx:sm:flex"
+    >
+      ⌘K
+    </kbd>
+  </div>
+
+  <div>
+    <ul
+      class="hextra-search-results hextra-scrollbar hx:hidden hx:border hx:border-gray-200 hx:bg-white hx:text-gray-100 hx:dark:border-neutral-800 hx:dark:bg-neutral-900 hx:absolute hx:top-full hx:z-20 hx:mt-2 hx:overflow-auto hx:overscroll-contain hx:rounded-xl hx:py-2.5 hx:shadow-xl hx:max-h-[min(calc(50vh-11rem-env(safe-area-inset-bottom)),400px)] hx:md:max-h-[min(calc(100vh-5rem-env(safe-area-inset-bottom)),400px)] hx:inset-x-0 hx:ltr:md:left-auto hx:rtl:md:right-auto hx:contrast-more:border hx:contrast-more:border-gray-900 hx:contrast-more:dark:border-gray-50 hx:w-screen hx:min-h-[100px] hx:max-w-[min(calc(100vw-2rem),calc(100%+20rem))]"
+      style="transition: max-height 0.2s ease 0s;"
+    ></ul>
+  </div>
+</div>

--- a/layouts/shortcodes/include-md.html
+++ b/layouts/shortcodes/include-md.html
@@ -8,6 +8,15 @@ Include error: missing file {{ $rel }}
   {{- else -}}
     {{- $raw := readFile $full -}}
     {{- $body := replaceRE `(?s)^---\n.*?\n---\n?` "" $raw -}}
+    {{- $headings := slice -}}
+    {{- range findRESubmatch `(?m)^(#{1,3})\s+(.+?)\s*$` $body -}}
+      {{- $marker := index . 1 -}}
+      {{- $text := index . 2 | replaceRE `\s+#+$` "" | replaceRE `<[^>]+>` "" | strings.TrimSpace -}}
+      {{- if $text -}}
+        {{- $headings = $headings | append (dict "level" (len $marker) "text" $text "id" (anchorize $text)) -}}
+      {{- end -}}
+    {{- end -}}
+    {{- .Page.Store.Set "includedHeadings" $headings -}}
     {{- $body | .Page.RenderString -}}
   {{- end -}}
 {{- end -}}

--- a/static/favicon-dark.svg
+++ b/static/favicon-dark.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <text x="16" y="16" text-anchor="middle" dominant-baseline="central"
+        font-family="system-ui, -apple-system, ui-sans-serif, sans-serif"
+        font-weight="760" font-size="22" letter-spacing="-1.2"
+        fill="#edf0f6">ai</text>
+</svg>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -2,5 +2,5 @@
   <text x="16" y="16" text-anchor="middle" dominant-baseline="central"
         font-family="system-ui, -apple-system, ui-sans-serif, sans-serif"
         font-weight="760" font-size="22" letter-spacing="-1.2"
-        fill="#151922">ai</text>
+        fill="#000000">ai</text>
 </svg>

--- a/static/favicon.svg
+++ b/static/favicon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <text x="16" y="16" text-anchor="middle" dominant-baseline="central"
+        font-family="system-ui, -apple-system, ui-sans-serif, sans-serif"
+        font-weight="760" font-size="22" letter-spacing="-1.2"
+        fill="#151922">ai</text>
+</svg>


### PR DESCRIPTION
## Summary
- Add local Hugo/Hextra layout overrides for a quieter, wider, minimal blog interface.
- Move search into the top-right nav with a visible Cmd+K affordance and keep the theme toggle nearby.
- Add compact blog rows with right-aligned publish dates and thin separators.
- Add custom article layout with wide content, sticky right-side index, and Copy as Markdown support for notebook-backed posts.
- Preserve heading hierarchy in the sidebar index, including headings rendered from included notebook Markdown.
- Make code block copy controls visible at the top right and rely on Hextra/Chroma default syntax colors instead of custom token overrides.
- Remove the TIL section from navigation/content.

## Notes
- Kept Hugo + Hextra rather than switching to the TypeScript/Next.js approach used by dwarez/blog, because this repo already has notebook bundle/export conventions and the missing index behavior was fixable locally.
- Updated the linear regression notebook source heading and regenerated its Markdown so the abstraction section appears in the article index.

## Verification
- `hugo --buildDrafts --cleanDestinationDir`
- `just marimo-export content/blog/01-groundup-linear-regression/linear_regression.py`