### PR TITLE
fix: replace deprecated languageCode with locale

### DIFF
--- a/hugo.yaml
+++ b/hugo.yaml
@@ -1,5 +1,5 @@
 baseURL: https://baggiponte.com/
-languageCode: en-us
+locale: en-us
 title: ai field notes
 
 author:


### PR DESCRIPTION
Hugo v0.158.0 deprecated the `languageCode` project config key in favor of `locale`. This PR updates `hugo.yaml` to use the new key, resolving the deprecation warning emitted by `hugo mod get -u`.