### PR TITLE
fix: remove duplicate post stubs for groundup linear series

### DIFF
--- a/content/blog/groundup-linear-classifier/index.md
+++ b/content/blog/groundup-linear-classifier/index.md
@@ -1,8 +1,0 @@
----
-title: "from the ground up: linear classifier"
-description: We move from linear regression to classification and build a logistic regression plus a more structured PyTorch training loop.
-date: 2026-02-18
-draft: true
----
-
-{{< include-md "linear_classifier.md" >}}

--- a/content/blog/groundup-linear-regression/index.md
+++ b/content/blog/groundup-linear-regression/index.md
@@ -1,7 +1,0 @@
----
-title: "from the ground up: linear regression"
-description: We implement a simple linear regression in PyTorch, introducing a couple of abstractions while keeping the training loop easy to follow.
-date: 2026-02-18
----
-
-{{< include-md "linear_regression.md" >}}


### PR DESCRIPTION
Remove stale non-prefixed `groundup-linear-regression` and `groundup-linear-classifier` directories that duplicated the canonical `01-`/`02-` prefixed bundles. The stubs only contained `index.md` with lowercase titles and referenced missing notebook `.md` files; the prefixed directories hold the complete notebook bundles.