### PR TITLE
fix: replace deprecated .Site.Language.LanguageCode with .Locale in RSS template

### DIFF
--- a/layouts/list.rss.xml
+++ b/layouts/list.rss.xml
@@ -4,7 +4,7 @@
     <title>{{ .Site.Title }} - {{ .Title }}</title>
     <link>{{ .Permalink }}</link>
     <description>Recent content {{ if ne .Title .Site.Title }}{{ with .Title }}in {{ . }} {{ end }}{{ end }}on {{ .Site.Title }}</description>
-    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.LanguageCode }}
+    <generator>Hugo -- gohugo.io</generator>{{ with .Site.Language.Locale }}
     <language>{{ . }}</language>{{ end }}{{ with $author.email }}
     <managingEditor>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</managingEditor>{{ end }}{{ with $author.email }}
     <webMaster>{{ . }}{{ with $author.name }} ({{ . }}){{ end }}</webMaster>{{ end }}{{ with .Site.Copyright }}


### PR DESCRIPTION
Hugo v0.158.0 deprecated `.Language.LanguageCode` in favor of `.Language.Locale`. Update the custom RSS template at `layouts/list.rss.xml` to use the new property, eliminating the remaining deprecation warning emitted during `hugo --gc`.