### PR TITLE
fix: lowercase all post and section titles

### DIFF
--- a/content/blog/01-groundup-linear-regression/index.md
+++ b/content/blog/01-groundup-linear-regression/index.md
@@ -1,5 +1,5 @@
 ---
-title: "From the Ground Up: Linear Regression"
+title: "from the ground up: linear regression"
 description: We implement a simple linear regression in PyTorch, introducing a couple of abstractions while keeping the training loop easy to follow.
 date: 2026-02-18
 ---

--- a/content/blog/01-groundup-linear-regression/linear_regression.md
+++ b/content/blog/01-groundup-linear-regression/linear_regression.md
@@ -1,5 +1,5 @@
 ---
-title: Linear Regression
+title: linear regression
 marimo-version: 0.23.14
 width: full
 sql_output: native
@@ -16,7 +16,7 @@ from torch import nn
 
 "From the ground up" is a series of short, technical blog posts about deep learning. This looks like "yet another deep learning from scratch" series, and partly it is - but it has a narrower focus on the abstractions (from `DataLoader`s to `Trainer`s) and performance. The goal of the series is, in other words, to understand the API design and how things are implemented, more so than the maths. This is chapter one, were we train a linear regression using stochastic gradient descent.
 <!---->
-# Linear Regression
+# linear regression
 <!---->
 ## Generate Data
 <!---->

--- a/content/blog/01-groundup-linear-regression/linear_regression.py
+++ b/content/blog/01-groundup-linear-regression/linear_regression.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.19.11"
-app = marimo.App(width="full", sql_output="native")
+app = marimo.App(width="full", sql_output="native", app_title="linear regression")
 
 with app.setup:
     from dataclasses import dataclass
@@ -23,7 +23,7 @@ def _():
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    # Linear Regression
+    # linear regression
     """)
     return
 

--- a/content/blog/02-groundup-linear-classifier/index.md
+++ b/content/blog/02-groundup-linear-classifier/index.md
@@ -1,5 +1,5 @@
 ---
-title: "From the Ground Up: Linear Classifier"
+title: "from the ground up: linear classifier"
 description: We move from linear regression to classification and build a logistic regression plus a more structured PyTorch training loop.
 date: 2026-02-18
 draft: true

--- a/content/blog/02-groundup-linear-classifier/linear_classifier.md
+++ b/content/blog/02-groundup-linear-classifier/linear_classifier.md
@@ -1,6 +1,6 @@
 ---
-title: Linear Classifier
-marimo-version: 0.19.11
+title: linear classification
+marimo-version: 0.23.14
 width: full
 sql_output: native
 ---
@@ -20,7 +20,7 @@ import torch.nn as nn
 import marimo as mo
 ```
 
-# Linear classification
+# linear classification
 <!---->
 Here we move from linear regression to classification. We implement a simple logistic regression using the same PyTorch and our own primitives.
 <!---->

--- a/content/blog/02-groundup-linear-classifier/linear_classifier.py
+++ b/content/blog/02-groundup-linear-classifier/linear_classifier.py
@@ -1,7 +1,7 @@
 import marimo
 
 __generated_with = "0.19.9"
-app = marimo.App(width="full", sql_output="native")
+app = marimo.App(width="full", sql_output="native", app_title="linear classification")
 
 with app.setup:
     import itertools
@@ -21,7 +21,7 @@ with app.setup:
 @app.cell(hide_code=True)
 def _():
     mo.md(r"""
-    # Linear classification
+    # linear classification
     """)
     return
 

--- a/content/blog/_index.md
+++ b/content/blog/_index.md
@@ -1,7 +1,7 @@
 ---
 date: '2025-06-13T19:50:07+02:00'
 draft: false
-title: 'Blog'
+title: 'blog'
 ---
 
 Long-form notes on machine learning, tools, and the engineering details around them.


### PR DESCRIPTION
Lowercase all post and section titles for consistency with the site's style convention. Changes:

- `content/blog/_index.md`: 'Blog' → 'blog'
- `content/blog/01-groundup-linear-regression/index.md`: "From the Ground Up: Linear Regression" → "from the ground up: linear regression"
- `content/blog/02-groundup-linear-classifier/index.md`: "From the Ground Up: Linear Classifier" → "from the ground up: linear classifier"
- Notebook `.py` files: update `app_title` metadata and `# heading` to lowercase
- Generated `.md` files: regenerated from updated notebooks