### PR TITLE
fix: bump CI Hugo version to 0.164.0

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -47,7 +47,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.147.7
+      HUGO_VERSION: 0.164.0
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
The deploy workflow was pinned to Hugo v0.147.7, which does not support the `locale` config key or `.Language.Locale` template property introduced in v0.158.0. Bump to v0.164.0 to match local development and fix the deploy failures that started after PRs #32 and #34 were merged.